### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,6 @@ Samples and Examples
 ====================
 
 The test code contains a number of examples and is well [documented]
-(https://github.com/Claudenw/junit-contracts/blob/master/src/test/java/org/xenei/junit/contract/README.md) for use as such.
+(https://github.com/Claudenw/junit-contracts/blob/master/junit/src/test/java/org/xenei/junit/contract/README.md) for use as such.
 
 The sample code tree includes a sample for a Serializable contract test.


### PR DESCRIPTION
Hi, the link changed is broken and I think it was supposed to point to https://github.com/Claudenw/junit-contracts/blob/master/junit/src/test/java/org/xenei/junit/contract/README.md.